### PR TITLE
Fix version-info for 8.9.0 and drop release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,9 +250,8 @@ endif
 ## The remainder of the object files
 libcryptopp_la_DEPENDENCIES += $(libothers_la_OBJECTS)
 
-## Man, did Autotools fuck this up royally...
 ## https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
-libcryptopp_la_LDFLAGS = $(AM_LDFLAGS) -release 8.8.0 -version-info 8:8
+libcryptopp_la_LDFLAGS = $(AM_LDFLAGS) -version-info 9:0:0
 
 ## Source files with special needs
 libcryptlib_la_SOURCES = cryptlib.cpp

--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ echo "Build is $build"
 ## configure.ac preamble
 #############################################################################
 
-AC_INIT([Crypto++], [8.8], [http://www.cryptopp.com/wiki/Bug_Report], [cryptopp], [http://www.cryptopp.com])
+AC_INIT([Crypto++], [8.9], [http://www.cryptopp.com/wiki/Bug_Report], [cryptopp], [http://www.cryptopp.com])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([local.h])
 AC_CONFIG_FILES([Makefile] [libcryptopp.pc])


### PR DESCRIPTION
This will lead to a libcryptopp.so.9 SONAME and libcryptopp.so.9.0.0 library.